### PR TITLE
fix: use raw string to circumvent undefined escape sequence

### DIFF
--- a/gmft/table_captioning.py
+++ b/gmft/table_captioning.py
@@ -567,7 +567,7 @@ def _find_caption_with_mu(ct: CroppedTable, **kwargs):
     top_captions = '\n'.join([c for c in top_captions if c]) # clear out empty captions
     bottom_captions = '\n'.join([c for c in bottom_captions if c])
     
-    whitespace_re = re.compile('\s*[\u202f\u2002\u2009\u00A0]\s*') #  \u2002 \u2009
+    whitespace_re = re.compile(r'\s*[\u202f\u2002\u2009\u00A0]\s*') #  \u2002 \u2009
     top_captions = re.sub(whitespace_re, ' ', top_captions).replace('\n', '')
     bottom_captions = re.sub(whitespace_re, ' ', bottom_captions).replace('\n', '')
     return top_captions, bottom_captions # ('\n'.join(top_captions), '\n'.join(bottom_captions))


### PR DESCRIPTION
Since Python 3.6 it has been deprecated to use undefined escape sequences (like `\s`) in strings and since Python 3.12 this raises a `SyntaxWarning`:

> _Changed in version 3.12_: Unrecognized escape sequences produce a [SyntaxWarning](https://docs.python.org/3/library/exceptions.html#SyntaxWarning). In a future Python version they will be eventually a [SyntaxError](https://docs.python.org/3/library/exceptions.html#SyntaxError).

https://docs.python.org/3/reference/lexical_analysis.html#escape-sequences

The easy way out is to use a raw string, which leaves the escape sequence as is and passes it to `re`.

This should get rid of this warning when importing this module in Python >= 3.12:

```
/usr/local/lib/python3.12/site-packages/gmft/table_captioning.py:570: SyntaxWarning: invalid escape sequence '\s'
  whitespace_re = re.compile('\s*[\u202f\u2002\u2009\u00A0]\s*') #  \u2002 \u2009
```