### PR TITLE
Fixed major import error in README.md #Quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ See the [docs](https://gmft.readthedocs.io/en/latest/usage.html) and the [config
 
 ```python
 # new in v0.3: gmft.auto
-from gmft.auto import CroppedTable, TableDetector, AutoTableFormatter
+from gmft.auto import CroppedTable, TableDetector, AutoTableFormatter, AutoTableDetector
 from gmft.pdf_bindings import PyPDFium2Document
 
 detector = AutoTableDetector()


### PR DESCRIPTION
The quickstart code doesn't actually work because `AutoTableDetector` isn't imported.

Added `AutoTableDetector` in imports.