### PR TITLE
feat: Bump version v0.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
+## v0.4.2
+
+Bugfixes before the upcoming release.
+- Better imports and lazy loading
+- Default device is now 'auto', which resolves to cuda/cpu depending on availability
+- Rich text now available as `AutoPageFormatter`
+    - Fixed bug with permuted coordinates (e0c6dc52)
+- CroppedTable now directly has `angle` property
+- CI tests, Python 3.9 support
+- More type hints
+- Light restructuring (non-breaking)
+- Internal data structure tweaks
+    - (`fctn_results` → `predictions.tatr`)
+    - (`effective_*` → `predictions.effective`)
+
 ## v0.4.0
 
 Features: 3 new table structure recognition options!

--- a/gmft/__init__.py
+++ b/gmft/__init__.py
@@ -1,140 +1,133 @@
 """
 Currently, contains aliases for key classes and functions.
 
-Unfortunately, although at one point the ability to import classes from the top level module (ie. `from gmft import AutoTableFormatter`) was encouraged,
-it is now discouraged and may be removed in future versions. The reason being: importing through the top level module
-loads the entire library, even when you're using only a small part of it.
+Importing from the top-level module previously resulted in long load times.
+However, v0.5 introduces lazy loading, which greatly improves the situation.
 
-Instead, `gmft.auto` is now encouraged. For example, `from gmft.auto import AutoTableFormatter`.
+Now, classes may either be imported from their original locations,
+`gmft.auto`, or from here, where they will be lazy loaded.
 """
 
+# small classes are fine, but discouraged.
 from gmft.base import Rect
+from gmft.core.legacy.mirror import DeprecationMirrorMeta
 from gmft.pdf_bindings.base import BasePDFDocument, BasePage
 from gmft.detectors.base import CroppedTable, RotatedCroppedTable
 from gmft.formatters.base import FormattedTable
 
-from gmft.auto import (
-    TATRDetector as TATRTableDetectorOrig,
-    TableDetectorConfig as TableDetectorConfigOrig,
-    TableDetector as TableDetectorOrig,
-    TATRFormatConfig as TATRFormatConfigOrig,
-    TATRFormattedTable as TATRFormattedTableOrig,
-    TATRFormatter as TATRTableFormatterOrig,
-    AutoTableFormatter as AutoTableFormatterOrig,
-    AutoFormatConfig as AutoFormatConfigOrig,
-    AutoTableDetector as AutoTableDetectorOrig,
+# config-only classes specific to TATR are still discouraged.
+
+# these auto classes are lazy-loaded
+from gmft.core.auto_lazy import (
+    AutoTableFormatter,
+    AutoFormatConfig,
+    AutoTableDetector,
 )
 
-has_warned = False
+# We need to support these imports for compatibility:
+# TATRTableDetector
+# TableDetectorConfig
+# TableDetector
+# TATRFormatConfig
+# TATRFormattedTable
+# TATRTableFormatter
+# AutoTableFormatter
+# AutoFormatConfig
+# AutoTableDetector
 
 
-def _deprecation_warning(name):
-    global has_warned
-    if has_warned:
-        return
-    import warnings
-
-    msg = f"(Deprecation) While once encouraged, \
-importing {name} and other classes from the top level module is now deprecated and will break in v0.5.0. \
-Please import from gmft.auto instead."
-    warnings.warn(msg, DeprecationWarning, stacklevel=2)
-    print(msg)
-    has_warned = True
-
-
-# These small classes are fine, but still discouraged.
-# Rect
-# BasePDFDocument
-# BasePage
-# CroppedTable
-# RotatedCroppedTable
-
-
-class TATRTableDetector(TATRTableDetectorOrig):
+# These bulky TATR-specific detectors are discouraged, but still available for compatibility.
+class TATRTableDetector(metaclass=DeprecationMirrorMeta):
     """
-    Deprecated. Please import from gmft.auto instead.
+    This import is deprecated.
+
+    Please use:
+    - gmft.AutoTableDetector
+    - gmft.detectors.tatr.TATRDetector
     """
 
-    def __init__(self, *args, **kwargs):
-        _deprecation_warning("TATRTableDetector")
-        super().__init__(*args, **kwargs)
+    @classmethod
+    def get_mirrored_class(cls):
+        from gmft.detectors.tatr import TATRDetector as OrigCls
+
+        return OrigCls
 
 
-class TableDetectorConfig(TableDetectorConfigOrig):
+class TableDetectorConfig(metaclass=DeprecationMirrorMeta):
     """
-    Deprecated. Please import from gmft.auto instead.
-    """
+    This import is deprecated.
 
-    def __init__(self, *args, **kwargs):
-        _deprecation_warning("TableDetectorConfig")
-        super().__init__(*args, **kwargs)
-
-
-class TableDetector(TableDetectorOrig):
-    """
-    Deprecated. Please import from gmft.auto instead.
+    Please use:
+    - Reformat API (v0.5)
+    - gmft.detectors.tatr.TATRDetectorConfig
     """
 
-    def __init__(self, *args, **kwargs):
-        _deprecation_warning("TableDetector")
-        super().__init__(*args, **kwargs)
+    @classmethod
+    def get_mirrored_class(cls):
+        from gmft.impl.tatr.config import TATRDetectorConfig as OrigCls
+
+        return OrigCls
 
 
-class TATRFormatConfig(TATRFormatConfigOrig):
+class TableDetector(metaclass=DeprecationMirrorMeta):
     """
-    Deprecated. Please import from gmft.auto instead.
-    """
+    This import is deprecated.
 
-    def __init__(self, *args, **kwargs):
-        _deprecation_warning("TATRFormatConfig")
-        super().__init__(*args, **kwargs)
-
-
-class TATRFormattedTable(TATRFormattedTableOrig):
-    """
-    Deprecated. Please import from gmft.auto instead.
+    Please use:
+    - gmft.AutoTableDetector
+    - gmft.detectors.tatr.TATRDetector
     """
 
-    def __init__(self, *args, **kwargs):
-        _deprecation_warning("TATRFormattedTable")
-        super().__init__(*args, **kwargs)
+    @classmethod
+    def get_mirrored_class(cls):
+        from gmft.auto import TATRDetector as OrigCls
+
+        return OrigCls
 
 
-class TATRTableFormatter(TATRTableFormatterOrig):
+class TATRFormatConfig(metaclass=DeprecationMirrorMeta):
     """
-    Deprecated. Please import from gmft.auto instead.
-    """
+    This import is deprecated.
 
-    def __init__(self, *args, **kwargs):
-        _deprecation_warning("TATRTableFormatter")
-        super().__init__(*args, **kwargs)
-
-
-class AutoTableFormatter(AutoTableFormatterOrig):
-    """
-    Deprecated. Please import from gmft.auto instead.
+    Please use:
+    - Reformat API (v0.5)
+    - gmft.formatters.tatr.TATRFormatConfig
     """
 
-    def __init__(self, *args, **kwargs):
-        _deprecation_warning("AutoTableFormatter")
-        super().__init__(*args, **kwargs)
+    @classmethod
+    def get_mirrored_class(cls):
+        from gmft.impl.tatr.config import TATRFormatConfig as OrigCls
+
+        return OrigCls
 
 
-class AutoFormatConfig(AutoFormatConfigOrig):
+class TATRFormattedTable(metaclass=DeprecationMirrorMeta):
     """
-    Deprecated. Please import from gmft.auto instead.
-    """
+    This import is deprecated.
 
-    def __init__(self, *args, **kwargs):
-        _deprecation_warning("AutoFormatConfig")
-        super().__init__(*args, **kwargs)
-
-
-class AutoTableDetector(AutoTableDetectorOrig):
-    """
-    Deprecated. Please import from gmft.auto instead.
+    Please use:
+    - Reformat API (v0.5)
+    - gmft.formatters.tatr.TATRFormattedTable
     """
 
-    def __init__(self, *args, **kwargs):
-        _deprecation_warning("AutoTableDetector")
-        super().__init__(*args, **kwargs)
+    @classmethod
+    def get_mirrored_class(cls):
+        from gmft.formatters.tatr import TATRFormattedTable as OrigCls
+
+        return OrigCls
+
+
+class TATRTableFormatter(metaclass=DeprecationMirrorMeta):
+    """
+    This import is deprecated.
+
+    Please use:
+    - gmft.auto.AutoTableFormatter
+    - gmft.formatters.tatr.TATRFormatter
+    """
+
+    @classmethod
+    def get_mirrored_class(cls):
+        from gmft.formatters.tatr import TATRFormatter as OrigCls
+
+        return OrigCls

--- a/gmft/algorithm/structure.py
+++ b/gmft/algorithm/structure.py
@@ -767,7 +767,7 @@ def extract_to_df(table: TATRFormattedTable, config: TATRFormatConfig = None):
 
     outliers = {}  # store table-wide information about outliers or pecularities
 
-    results = table.predictions["tatr"]
+    results = table.predictions.tatr
 
     # 1. collate identified boxes
     boxes = []
@@ -889,8 +889,9 @@ def extract_to_df(table: TATRFormattedTable, config: TATRFormatConfig = None):
         if not known_means:
             # no text was detected
             outliers["no text"] = True
-            table.predictions["effective"] = _empty_effective_predictions()
-            table.predictions["indices"] = _empty_indices_predictions()
+            table.predictions.effective = _empty_effective_predictions()
+            table.predictions.indices = _empty_indices_predictions()
+            table.predictions.status = "ready"
             table._df = pd.DataFrame()
             table.outliers = outliers
             return table._df
@@ -930,7 +931,7 @@ def extract_to_df(table: TATRFormattedTable, config: TATRFormatConfig = None):
         )
 
     # nms takes care of deduplication
-    table.predictions["effective"] = {
+    table.predictions.effective = {
         "rows": sorted_rows,
         "columns": sorted_columns,
         "headers": sorted_headers,
@@ -1071,7 +1072,8 @@ def extract_to_df(table: TATRFormattedTable, config: TATRFormatConfig = None):
         ]
         indices_preds["_projecting"] = [i for i, x in enumerate(is_projecting) if x]
 
-    table.predictions["indices"] = indices_preds
+    table.predictions.indices = indices_preds
+    table.predictions.status = "ready"
 
     # if projecting_indices:
     # insert at end

--- a/gmft/auto.py
+++ b/gmft/auto.py
@@ -22,41 +22,8 @@ TATRTableDetector = TATRDetector
 TATRTableFormatter = TATRFormatter
 # TATRFormatConfig = TATRFormatConfig
 
-
-class AutoTableFormatter:
-    """
-    The recommended :class:`~gmft.formatters.base.BaseFormatter`. Currently points to :class:`~gmft.formatters.tatr.TATRFormatter`.
-    Uses a TableTransformerForObjectDetection for small/medium tables, and a custom algorithm for large tables.
-
-    Using :meth:`extract`, a :class:`~gmft.formatters.base.FormattedTable` is produced, which can be exported to csv, df, etc.
-    """
-
-    def __new__(cls, *args, **kwargs):
-        from gmft.formatters.tatr import TATRFormatter
-
-        return TATRFormatter(*args, **kwargs)
-
-
-class AutoFormatConfig:
-    """
-    Configuration for the recommended :class:`~gmft.formatters.base.BaseFormatter`. Currently points to :class:`~gmft.formatters.tatr.TATRFormatConfig`.
-    """
-
-    def __new__(cls, *args, **kwargs):
-        from gmft.impl.tatr.config import TATRFormatConfig
-
-        return TATRFormatConfig(*args, **kwargs)
-
-
-class AutoTableDetector:
-    """
-    The recommended :class:`~gmft.detectors.base.BaseDetector`. Currently points to :class:`~gmft.detectors.tatr.TATRDetector`.
-    Uses TableTransformerForObjectDetection for small/medium tables, and a custom algorithm for large tables.
-
-    Using :meth:`~gmft.detectors.base.BaseDetector.extract` produces a :class:`~gmft.formatters.base.FormattedTable`, which can be exported to csv, df, etc.
-    """
-
-    def __new__(cls, *args, **kwargs):
-        from gmft.detectors.tatr import TATRDetector
-
-        return TATRDetector(*args, **kwargs)
+from gmft.core.auto_lazy import (
+    AutoTableFormatter,
+    AutoFormatConfig,
+    AutoTableDetector,
+)

--- a/gmft/core/auto_lazy.py
+++ b/gmft/core/auto_lazy.py
@@ -1,0 +1,37 @@
+class AutoTableFormatter:
+    """
+    The recommended :class:`~gmft.formatters.base.BaseFormatter`. Currently points to :class:`~gmft.formatters.tatr.TATRFormatter`.
+    Uses a TableTransformerForObjectDetection for small/medium tables, and a custom algorithm for large tables.
+
+    Using :meth:`extract`, a :class:`~gmft.formatters.base.FormattedTable` is produced, which can be exported to csv, df, etc.
+    """
+
+    def __new__(cls, *args, **kwargs):
+        from gmft.formatters.tatr import TATRFormatter
+
+        return TATRFormatter(*args, **kwargs)
+
+
+class AutoFormatConfig:
+    """
+    Configuration for the recommended :class:`~gmft.formatters.base.BaseFormatter`. Currently points to :class:`~gmft.formatters.tatr.TATRFormatConfig`.
+    """
+
+    def __new__(cls, *args, **kwargs):
+        from gmft.impl.tatr.config import TATRFormatConfig
+
+        return TATRFormatConfig(*args, **kwargs)
+
+
+class AutoTableDetector:
+    """
+    The recommended :class:`~gmft.detectors.base.BaseDetector`. Currently points to :class:`~gmft.detectors.tatr.TATRDetector`.
+    Uses TableTransformerForObjectDetection for small/medium tables, and a custom algorithm for large tables.
+
+    Using :meth:`~gmft.detectors.base.BaseDetector.extract` produces a :class:`~gmft.formatters.base.FormattedTable`, which can be exported to csv, df, etc.
+    """
+
+    def __new__(cls, *args, **kwargs):
+        from gmft.detectors.tatr import TATRDetector
+
+        return TATRDetector(*args, **kwargs)

--- a/gmft/core/io/serial/dicts.py
+++ b/gmft/core/io/serial/dicts.py
@@ -3,6 +3,7 @@ from typing import Optional
 from gmft.core.ml.prediction import (
     IndicesPredictions,
     RawBboxPredictions,
+    _empty_effective_predictions,
     _empty_indices_predictions,
 )
 from gmft.detectors.base import CroppedTable
@@ -57,3 +58,11 @@ def _extract_indices(d: dict) -> IndicesPredictions:
         }
 
     return _empty_indices_predictions()
+
+
+def _extract_effective(d: dict) -> IndicesPredictions:
+    # version gmft>=0.5 format
+    if "predictions.effective" in d:
+        return d["predictions.effective"]
+
+    return _empty_effective_predictions()

--- a/gmft/core/legacy/fctn_results.py
+++ b/gmft/core/legacy/fctn_results.py
@@ -14,91 +14,91 @@ class LegacyFctnResults:
     predictions: TablePredictions
 
     @property
-    @deprecated("Use self.predictions['tatr']")
+    @deprecated("Use self.predictions.tatr")
     def fctn_results(self) -> RawBboxPredictions:
-        return self.predictions["tatr"]
+        return self.predictions.tatr
 
     @fctn_results.setter
-    @deprecated("Use self.predictions['tatr']")
+    @deprecated("Use self.predictions.tatr")
     def fctn_results(self, value: RawBboxPredictions):
-        self.predictions["tatr"] = value
+        self.predictions.tatr = value
 
     @property
-    @deprecated("Use self.predictions['effective']")
+    @deprecated("Use self.predictions.effective")
     def effective_rows(self):
-        return self.predictions["effective"]["rows"]
+        return self.predictions.effective["rows"]
 
     @effective_rows.setter
-    @deprecated("Use self.predictions['effective']")
+    @deprecated("Use self.predictions.effective")
     def effective_rows(self, value):
-        self.predictions["effective"]["rows"] = value
+        self.predictions.effective["rows"] = value
 
     @property
-    @deprecated("Use self.predictions['effective']")
+    @deprecated("Use self.predictions.effective")
     def effective_columns(self):
-        return self.predictions["effective"]["columns"]
+        return self.predictions.effective["columns"]
 
     @effective_columns.setter
-    @deprecated("Use self.predictions['effective']")
+    @deprecated("Use self.predictions.effective")
     def effective_columns(self, value):
-        self.predictions["effective"]["columns"] = value
+        self.predictions.effective["columns"] = value
 
     @property
-    @deprecated("Use self.predictions['effective']")
+    @deprecated("Use self.predictions.effective")
     def effective_headers(self):
-        return self.predictions["effective"]["headers"]
+        return self.predictions.effective["headers"]
 
     @effective_headers.setter
-    @deprecated("Use self.predictions['effective']")
+    @deprecated("Use self.predictions.effective")
     def effective_headers(self, value):
-        self.predictions["effective"]["headers"] = value
+        self.predictions.effective["headers"] = value
 
     @property
-    @deprecated("Use self.predictions['effective']")
+    @deprecated("Use self.predictions.effective")
     def effective_projecting(self):
-        return self.predictions["effective"]["projecting"]
+        return self.predictions.effective["projecting"]
 
     @effective_projecting.setter
-    @deprecated("Use self.predictions['effective']")
+    @deprecated("Use self.predictions.effective")
     def effective_projecting(self, value):
-        self.predictions["effective"]["projecting"] = value
+        self.predictions.effective["projecting"] = value
 
     @property
-    @deprecated("Use self.predictions['effective']")
+    @deprecated("Use self.predictions.effective")
     def effective_spanning(self):
-        return self.predictions["effective"]["spanning"]
+        return self.predictions.effective["spanning"]
 
     @effective_spanning.setter
-    @deprecated("Use self.predictions['effective']")
+    @deprecated("Use self.predictions.effective")
     def effective_spanning(self, value):
-        self.predictions["effective"]["spanning"] = value
+        self.predictions.effective["spanning"] = value
 
     @property
-    @deprecated("Use self.predictions['indices']['top_header']")
+    @deprecated("Use self.predictions.indices['top_header']")
     def _top_header_indices(self):
-        return self.predictions["indices"].get("top_header")
+        return self.predictions.indices.get("top_header")
 
     @_top_header_indices.setter
-    @deprecated("Use self.predictions['indices']['_top_header']")
+    @deprecated("Use self.predictions.indices['_top_header']")
     def _top_header_indices(self, value):
-        self.predictions["indices"]["_top_header"] = value
+        self.predictions.indices["_top_header"] = value
 
     @property
-    @deprecated("Use self.predictions['indices']['_projecting']")
+    @deprecated("Use self.predictions.indices['_projecting']")
     def _projecting_indices(self):
-        return self.predictions["indices"].get("_projecting")
+        return self.predictions.indices.get("_projecting")
 
     @_projecting_indices.setter
-    @deprecated("Use self.predictions['indices']['_projecting']")
+    @deprecated("Use self.predictions.indices['_projecting']")
     def _projecting_indices(self, value):
-        self.predictions["indices"]["_projecting"] = value
+        self.predictions.indices["_projecting"] = value
 
     @property
-    @deprecated("Use self.predictions['indices']['_hier_left']")
+    @deprecated("Use self.predictions.indices['_hier_left']")
     def _hier_left_indices(self):
-        return self.predictions["indices"].get("_hier_left")
+        return self.predictions.indices.get("_hier_left")
 
     @_hier_left_indices.setter
-    @deprecated("Use self.predictions['indices']['hier_left']")
+    @deprecated("Use self.predictions.indices['hier_left']")
     def _hier_left_indices(self, value):
-        self.predictions["indices"]["hier_left"] = value
+        self.predictions.indices["hier_left"] = value

--- a/gmft/core/legacy/mirror.py
+++ b/gmft/core/legacy/mirror.py
@@ -1,0 +1,47 @@
+has_warned = False
+
+
+def _deprecation_warning(name):
+    global has_warned
+    if has_warned:
+        return
+    import warnings
+
+    msg = (
+        f"(Deprecation) Importing {name} et al. from the top level module is deprecated. \
+Refer to the import guide, or import from gmft.auto."  # TODO: add documentation link
+    )
+    warnings.warn(msg, DeprecationWarning, stacklevel=2)
+    print(msg)
+    has_warned = True
+
+
+class DeprecationMirrorMeta(type):
+    """
+    A metaclass that wraps a class to issue a deprecation warning when instantiated.
+
+    It mirrors a class (which needs to provided as a classmethod `get_mirrored_class`).
+
+    Though the power of magic, the class and wrapped class will be nearly equivalent.
+    `isinstance()` is modified so that the original class and wrapped class are interchangeable.
+    """
+
+    def __init__(cls, name, bases, dct):
+        # Call the classmethod to get the real class
+        # cls._orig_cls = cls.get_mirrored_class()
+        super().__init__(name, bases, dct)
+
+    def __call__(cls, *args, **kwargs):
+        # Issue warning once per instantiation
+        _deprecation_warning(cls.__name__)
+        instance = cls.get_mirrored_class()(*args, **kwargs)
+        # instance.__class__ = cls  # Make it look like the wrapper
+        return instance
+
+    def __instancecheck__(cls, instance):
+        """
+        Allow isinstance checks to work with the original class OR the wrapped class.
+        """
+        return isinstance(instance, cls.get_mirrored_class()) or isinstance(
+            instance, cls
+        )

--- a/gmft/core/ml/prediction/__init__.py
+++ b/gmft/core/ml/prediction/__init__.py
@@ -1,4 +1,5 @@
-from typing import Optional, Tuple, TypedDict, List, Union
+from dataclasses import dataclass
+from typing import Literal, Optional, Tuple, TypedDict, List, Union
 from typing_extensions import NotRequired
 
 
@@ -47,13 +48,16 @@ class IndicesPredictions(TypedDict):
     _hier_left: NotRequired[List[int]]
 
 
-class TablePredictions(TypedDict):
+@dataclass
+class TablePredictions:
     """Type definition for the complete predictions dictionary."""
 
     tatr: RawBboxPredictions
 
     effective: EffectivePredictions
     indices: IndicesPredictions
+
+    status: Literal["unready", "ready"] = "unready"
 
 
 def _empty_effective_predictions():

--- a/gmft/detectors/tatr.py
+++ b/gmft/detectors/tatr.py
@@ -5,41 +5,8 @@ from gmft.core._dataclasses import with_config
 from gmft.core.ml import _resolve_device
 from gmft.detectors.base import BaseDetector, CroppedTable, RotatedCroppedTable
 
+from gmft.impl.tatr.config import TATRDetectorConfig
 from gmft.pdf_bindings.base import BasePage
-
-
-@dataclass
-class TATRDetectorConfig:
-    """
-    Configuration for the :class:`.TATRDetector` class.
-
-    Specific to the TableTransformerForObjectDetection model. (Do not subclass this.)
-    """
-
-    image_processor_path: str = "microsoft/table-transformer-detection"
-    detector_path: str = "microsoft/table-transformer-detection"
-    no_timm: bool = True  # huggingface revision
-    warn_uninitialized_weights: bool = False
-    torch_device: str = "cuda" if torch.cuda.is_available() else "cpu"
-
-    detector_base_threshold: float = 0.9
-    """Minimum confidence score required for a table"""
-
-    @property
-    def confidence_score_threshold(self):
-        raise DeprecationWarning(
-            "Use detector_base_threshold instead. Will break in v0.6.0."
-        )
-
-    @confidence_score_threshold.setter
-    def confidence_score_threshold(self, value):
-        raise DeprecationWarning(
-            "Use detector_base_threshold instead. Will break in v0.6.0."
-        )
-
-    def __post_init__(self):
-        # use cuda if available
-        pass
 
 
 class TATRDetector(BaseDetector[TATRDetectorConfig]):

--- a/gmft/impl/tatr/config.py
+++ b/gmft/impl/tatr/config.py
@@ -9,6 +9,40 @@ from gmft.core.legacy.removed_config import LegacyRemovedConfig
 
 
 @dataclass
+class TATRDetectorConfig:
+    """
+    Configuration for the :class:`.TATRDetector` class.
+
+    Specific to the TableTransformerForObjectDetection model. (Do not subclass this.)
+    """
+
+    image_processor_path: str = "microsoft/table-transformer-detection"
+    detector_path: str = "microsoft/table-transformer-detection"
+    no_timm: bool = True  # huggingface revision
+    warn_uninitialized_weights: bool = False
+    torch_device: str = "cuda" if torch.cuda.is_available() else "cpu"
+
+    detector_base_threshold: float = 0.9
+    """Minimum confidence score required for a table"""
+
+    @property
+    def confidence_score_threshold(self):
+        raise DeprecationWarning(
+            "Use detector_base_threshold instead. Will break in v0.6.0."
+        )
+
+    @confidence_score_threshold.setter
+    def confidence_score_threshold(self, value):
+        raise DeprecationWarning(
+            "Use detector_base_threshold instead. Will break in v0.6.0."
+        )
+
+    def __post_init__(self):
+        # use cuda if available
+        pass
+
+
+@dataclass
 class TATRFormatConfig(LegacyRemovedConfig):
     """
     Configuration for :class:`.TATRTableFormatter`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gmft"
-version = "0.4.1"
+version = "0.4.2"
 description = "Lightweight, performant, deep table extraction"
 authors = [
     { name = "conjunct" },

--- a/test/compat/test_imports.py
+++ b/test/compat/test_imports.py
@@ -51,14 +51,33 @@ def test_aliases():
 
     assert isinstance(ct, CroppedTableOrig)
 
-    from gmft import TATRFormatConfig
 
-    config = TATRFormatConfig(large_table_threshold=2)
+def test_idem_isinstance():
+    # test that isinstance(self, cls) is true
+    # which is tricky with lazy-loaded classes
+    from gmft import TATRFormatConfig as LazyConfig
+
+    from gmft.impl.tatr.config import TATRFormatConfig as OrigConfig
+
+    config = LazyConfig(large_table_threshold=2)
     assert config.large_table_threshold == 2
 
-    assert isinstance(config, TATRFormatConfig)
+    # check is instanceof self
+    assert isinstance(config, LazyConfig)
 
+    # check equivalency of OrigConfig and TATRFormatConfig
+    assert isinstance(config, OrigConfig)
+
+    config_orig = OrigConfig(large_table_threshold=3)
+    assert config_orig.large_table_threshold == 3
+
+    assert isinstance(config_orig, OrigConfig)
+    assert isinstance(config_orig, LazyConfig)  # FAILS
+
+
+def test_common_alias():
     # import from "common" as an alias for "base"
+    from gmft import Rect
     from gmft.common import Rect as CommonRect
     from gmft.formatters.common import BaseFormatter
 

--- a/test/formatters/ditr/test_df.py
+++ b/test/formatters/ditr/test_df.py
@@ -95,7 +95,7 @@ class TestPdf5:
         pass  # this one just doesn't work very well
         # TODO make it work based on minima
         # try_jth_table(pdf5_tables, 5, 0)
-        # assert pdf5_tables[0].predictions["indices"]["_projecting"] == [15, 18, 22, 29]
+        # assert pdf5_tables[0].predictions.indices["_projecting"] == [15, 18, 22, 29]
 
     def test_bulk_pdf5_t1(self, ditr_tables, ditr_csvs, docs_bulk):
         try_table("pdf5_t1", ditr_tables, ditr_csvs, docs_bulk[5 - 1])

--- a/test/formatters/histogram/test_df.py
+++ b/test/formatters/histogram/test_df.py
@@ -112,7 +112,7 @@ class TestPdf5:
         pass  # this one just doesn't work very well
         # TODO make it work based on minima
         # try_jth_table(pdf5_tables, 5, 0)
-        # assert pdf5_tables[0].predictions["indices"]["_projecting"] == [15, 18, 22, 29]
+        # assert pdf5_tables[0].predictions.indices["_projecting"] == [15, 18, 22, 29]
 
     def test_bulk_pdf5_t1(self, pdf5_tables, tatr_csvs):
         try_jth_table(pdf5_tables, tatr_csvs, 5, 1)

--- a/test/formatters/tatr/test_df.py
+++ b/test/formatters/tatr/test_df.py
@@ -92,11 +92,11 @@ class TestPdf2:
     def test_bulk_pdf2_t1(self, pdf2_tables, tatr_csvs):
         try_jth_table(pdf2_tables, tatr_csvs, 2, 1)
         # hint: subtract 2 from the line no to get the proj. index (assume 1 header)
-        assert pdf2_tables[1].predictions["indices"]["_projecting"] == [9, 12, 16]
+        assert pdf2_tables[1].predictions.indices["_projecting"] == [9, 12, 16]
 
     def test_bulk_pdf2_t2(self, pdf2_tables, tatr_csvs):
         try_jth_table(pdf2_tables, tatr_csvs, 2, 2)
-        assert pdf2_tables[2].predictions["indices"]["_projecting"] == [0, 5]
+        assert pdf2_tables[2].predictions.indices["_projecting"] == [0, 5]
 
     def test_bulk_pdf2_t3(self, pdf2_tables, tatr_csvs):
         try_jth_table(pdf2_tables, tatr_csvs, 2, 3)
@@ -112,7 +112,7 @@ class TestPdf3:
 
     def test_bulk_pdf3_t2(self, pdf3_tables, tatr_csvs):
         try_jth_table(pdf3_tables, tatr_csvs, 3, 2)
-        assert pdf3_tables[2].predictions["indices"]["_projecting"] == [0, 8]
+        assert pdf3_tables[2].predictions.indices["_projecting"] == [0, 8]
 
     def test_bulk_pdf3_t3(self, pdf3_tables, tatr_csvs):
         try_jth_table(pdf3_tables, tatr_csvs, 3, 3)
@@ -124,17 +124,17 @@ class TestPdf4:
 
     def test_bulk_pdf4_t1(self, pdf4_tables, tatr_csvs):
         try_jth_table(pdf4_tables, tatr_csvs, 4, 1)
-        assert pdf4_tables[1].predictions["indices"]["_projecting"] == [0, 14]
+        assert pdf4_tables[1].predictions.indices["_projecting"] == [0, 14]
 
 
 class TestPdf5:
     def test_bulk_pdf5_t0(self, pdf5_tables, tatr_csvs):
         try_jth_table(pdf5_tables, tatr_csvs, 5, 0)
-        assert pdf5_tables[0].predictions["indices"]["_projecting"] == [15, 18, 22, 29]
+        assert pdf5_tables[0].predictions.indices["_projecting"] == [15, 18, 22, 29]
 
     def test_bulk_pdf5_t1(self, pdf5_tables, tatr_csvs):
         try_jth_table(pdf5_tables, tatr_csvs, 5, 1)
-        assert pdf5_tables[1].predictions["indices"]["_projecting"] == [13, 16, 22, 26]
+        assert pdf5_tables[1].predictions.indices["_projecting"] == [13, 16, 22, 26]
 
 
 class TestPdf6:

--- a/test/formatters/tatr/test_spanning.py
+++ b/test/formatters/tatr/test_spanning.py
@@ -178,7 +178,7 @@ Plasma Neu5Ac,"Css,ave (ng/mL)",,,,,
 
         try_jth_table(pdf2_tables, 2, 2, expected, config=config2)
 
-        assert pdf2_tables[2].predictions["indices"]["_projecting"] == [0, 5]
+        assert pdf2_tables[2].predictions.indices["_projecting"] == [0, 5]
 
     # pdf4 t1 is arguably HierTop, but the ground truth is not yet clear
 

--- a/test/formatters/tatr/test_visualize.py
+++ b/test/formatters/tatr/test_visualize.py
@@ -15,7 +15,7 @@ from gmft.impl.tatr.config import TATRFormatConfig
 #             self._img_margin = (0, 0, 0, 0)
 #             self.angle = 0
 #             self._df = None
-#             self.predictions = {}
+#             self.predictions = TablePredictions(TODO)
 #             self.image_shape = (100, 100, 3)
 
 #         def image(self, dpi=None, padding=None, margin=None):


### PR DESCRIPTION
Bugfixes before v0.5.0.
- Better imports and lazy loading
- Default device is now 'auto', which resolves to cuda/cpu depending on availability
- Rich text now available as `AutoPageFormatter`
    - Fixed bug with permuted coordinates (e0c6dc52)
- CroppedTable now directly has `angle` property
- CI tests, Python 3.9 support
- More type hints
- Light restructuring (non-breaking)
- Internal data structure tweaks
    - (`fctn_results` → `predictions.tatr`)
    - (`effective_*` → `predictions.effective`)